### PR TITLE
Fix encoder jittering

### DIFF
--- a/MsfsPlugin/MsfsPlugin/event/Binding.cs
+++ b/MsfsPlugin/MsfsPlugin/event/Binding.cs
@@ -6,6 +6,8 @@
 
     public class Binding
     {
+        private UInt64 LastMessageId;
+
         private Int64 _MSFSPreviousValue;
         private Int64 _ControllerPreviousValue;
         public Int64 ControllerValue { get; set; }
@@ -18,15 +20,19 @@
         public Boolean HasMSFSChanged() => this.MSFSChanged;
         public void SetMsfsValue(Int64 newValue)
         {
-            this.MSFSChanged = !this._MSFSPreviousValue.Equals(this.MsfsValue);
-            this._MSFSPreviousValue = this.MsfsValue;
-            this.MsfsValue = newValue;
+            if (this.LastMessageId < MsfsData.Instance.MessageId)
+            {
+                this.MSFSChanged = !this._MSFSPreviousValue.Equals(this.MsfsValue);
+                this._MSFSPreviousValue = this.MsfsValue;
+                this.MsfsValue = newValue;
+            }
         }
         public void SetControllerValue(Int64 newValue)
         {
             this.ControllerChanged = true;
             this._ControllerPreviousValue = this.ControllerValue;
             this.ControllerValue = newValue;
+            this.LastMessageId = MsfsData.Instance.MessageId;
             SimConnectDAO.Instance.Connect();
         }
         public void Reset()

--- a/MsfsPlugin/MsfsPlugin/msfs/MsfsData.cs
+++ b/MsfsPlugin/MsfsPlugin/msfs/MsfsData.cs
@@ -12,12 +12,14 @@
         public static MsfsData Instance => lazy.Value;
         public MSFSPlugin plugin { get; set; }
         public Boolean DEBUG { get; set; }
+        public UInt64 MessageId { get; set; }
         public String AircraftName { get; set; }
         public String DebugValue1 { get; set; }
         public String DebugValue2 { get; set; }
         public String DebugValue3 { get; set; }
         private MsfsData()
         {
+            this.MessageId = 0;
         }
 
         public void Register(Notifiable notif) => this.notifiables.Add(notif);
@@ -35,6 +37,7 @@
         {
             lock (this)
             {
+                this.MessageId++;
                 this.plugin.OnActionImageChanged(null, null, true);
                 foreach (Notifiable notifiable in this.notifiables)
                 {


### PR DESCRIPTION
There's a delay between when the plugin sends an updated encoder value to the sim and when it receives it back from SimConnect and updates the encoder value again. This often causes the value to erratically jump up and down while a dial is being rotated in several quick moves (e.g. for larger adjustments). This small patch corrects the issue.