### PR TITLE
Fixes for WP display and centralization of notification code

### DIFF
--- a/MsfsPlugin/MsfsPlugin/MsfsPlugin.csproj
+++ b/MsfsPlugin/MsfsPlugin/MsfsPlugin.csproj
@@ -141,6 +141,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="tools\CommonEntity.cs" />
     <Compile Include="tools\DebugTracing.cs" />
     <Compile Include="tools\DecimalValueAdjuster.cs" />
     <Compile Include="tools\ImageTool.cs" />

--- a/MsfsPlugin/MsfsPlugin/encoder/BarometerEncoder.cs
+++ b/MsfsPlugin/MsfsPlugin/encoder/BarometerEncoder.cs
@@ -7,8 +7,8 @@
     {
         public BarometerEncoder() : base("Baro", "Barometer encoder", "Nav", true, 2799, 3201, 1)
         {
-            bindings.Add(kohlsman = Register(BindingKeys.KOHLSMAN));                  // Value is 10000 times the actual value (rounded to long)
-            bindings.Add(pressure = Register(BindingKeys.SEA_LEVEL_PRESSURE));
+            kohlsman = Bind(BindingKeys.KOHLSMAN);                  // Value is 10000 times the actual value (rounded to long)
+            pressure = Bind(BindingKeys.SEA_LEVEL_PRESSURE);
         }
 
         protected override void RunCommand(string actionParameter) => SetValue(ConvertTool.RoundToLong(pressure.MsfsValue / ConvertTool.inHg2mbar * 1000d));

--- a/MsfsPlugin/MsfsPlugin/encoder/DefaultEncoder.cs
+++ b/MsfsPlugin/MsfsPlugin/encoder/DefaultEncoder.cs
@@ -9,13 +9,14 @@
         protected int min;
         protected int max;
         protected int step;
-        protected readonly List<Binding> bindings = new List<Binding>();
+        protected IList<Binding> bindings => entity.bindings;   //>> Can be removed when all encoders declare individual bindings
 
         protected DefaultEncoder(string name, string desc, string category, bool resettable, int min, int max, int step) : base(name, desc, category, resettable)
         {
             this.min = min;
             this.max = max;
             this.step = step;
+            entity = new CommonEntity();
             MsfsData.Instance.Register(this);
         }
 
@@ -25,22 +26,20 @@
             ActionImageChanged();
         }
 
+        protected static Binding Register(BindingKeys key) => MsfsData.Instance.Register(key);   //>> Can be removed when all encoders declare individual bindings
+
+        protected Binding Bind(BindingKeys key) => entity.Bind(key);
+
+        public void Notify() => entity.Notify();
+
         protected override string GetAdjustmentValue(string actionParameter) => GetDisplayValue();
 
-        public void Notify()
-        {
-            foreach (Binding binding in bindings)
-            {
-                if (binding.HasMSFSChanged())
-                {
-                    binding.Reset();
-                }
-            }
-        }
-
-        protected static Binding Register(BindingKeys key) => MsfsData.Instance.Register(key);
         protected virtual string GetDisplayValue() => GetValue().ToString();
+
         protected virtual long GetValue() => 0;
+
         protected abstract void SetValue(long value);
+
+        readonly CommonEntity entity;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/encoder/HeadingAPEncoder.cs
+++ b/MsfsPlugin/MsfsPlugin/encoder/HeadingAPEncoder.cs
@@ -7,8 +7,8 @@
     {
         public HeadingAPEncoder() : base("Head", "Autopilot heading encoder", "AP", true, 1, 360, 1)
         {
-            bindings.Add(ApHeading = Register(BindingKeys.AP_HEADING));
-            bindings.Add(Heading = Register(BindingKeys.HEADING));
+            ApHeading = Bind(BindingKeys.AP_HEADING);
+            Heading = Bind(BindingKeys.HEADING);
         }
 
         protected override void RunCommand(string actionParameter) => SetValue(Heading.ControllerValue);

--- a/MsfsPlugin/MsfsPlugin/folder/APDynamicFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/APDynamicFolder.cs
@@ -9,25 +9,24 @@
     {
         public APDynamicFolder() : base("AP")
         {
-            bindings.Add(Register(BindingKeys.AP_ALT));
-            bindings.Add(Register(BindingKeys.ALT));
-            bindings.Add(Register(BindingKeys.AP_HEADING));
-            bindings.Add(Register(BindingKeys.HEADING));
-            bindings.Add(Register(BindingKeys.AP_SPEED));
-            bindings.Add(Register(BindingKeys.SPEED));
-            bindings.Add(Register(BindingKeys.AP_VSPEED));
-            bindings.Add(Register(BindingKeys.VSPEED));
+            ApAltSetting = Bind(BindingKeys.AP_ALT);
+            PlaneAltitude = Bind(BindingKeys.ALT);
+            ApHdgSetting = Bind(BindingKeys.AP_HEADING);
+            PlaneHeading = Bind(BindingKeys.HEADING);
+            ApSpeedSetting = Bind(BindingKeys.AP_SPEED);
+            PlaneSpeed = Bind(BindingKeys.SPEED);
+            ApVspeedSetting = Bind(BindingKeys.AP_VSPEED);
+            PlaneVspeed = Bind(BindingKeys.VSPEED);
 
-            bindings.Add(Register(BindingKeys.AP_ALT_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_HEAD_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_NAV_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_SPEED_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_MASTER_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_THROTTLE_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_VSPEED_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_YAW_DAMPER_SWITCH));
-            bindings.Add(Register(BindingKeys.AP_BC_SWITCH));
-
+            MasterSwitch = Bind(BindingKeys.AP_MASTER_SWITCH);
+            AltSwitch = Bind(BindingKeys.AP_ALT_SWITCH);
+            HeadingSwitch = Bind(BindingKeys.AP_HEAD_SWITCH);
+            NavSwitch = Bind(BindingKeys.AP_NAV_SWITCH);
+            SpeedSwitch = Bind(BindingKeys.AP_SPEED_SWITCH);
+            ThrottleSwitch = Bind(BindingKeys.AP_THROTTLE_SWITCH);
+            VspeedSwitch = Bind(BindingKeys.AP_VSPEED_SWITCH);
+            YdSwitch = Bind(BindingKeys.AP_YAW_DAMPER_SWITCH);
+            BcSwitch = Bind(BindingKeys.AP_BC_SWITCH);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.None;
@@ -75,16 +74,16 @@
             switch (actionParameter)
             {
                 case "Altitude Encoder":
-                    ret = "Alt\n[" + bindings[0].ControllerValue + "]\n" + bindings[1].ControllerValue;
+                    ret = "Alt\n[" + ApAltSetting.ControllerValue + "]\n" + PlaneAltitude.ControllerValue;
                     break;
                 case "Heading Encoder":
-                    ret = "Head\n[" + bindings[2].ControllerValue + "]\n" + bindings[3].ControllerValue;
+                    ret = "Head\n[" + ApHdgSetting.ControllerValue + "]\n" + PlaneHeading.ControllerValue;
                     break;
                 case "Speed Encoder":
-                    ret = "Speed\n[" + bindings[4].ControllerValue + "]\n" + bindings[5].ControllerValue;
+                    ret = "Speed\n[" + ApSpeedSetting.ControllerValue + "]\n" + PlaneSpeed.ControllerValue;
                     break;
                 case "VS Speed Encoder":
-                    ret = "VS\n[" + bindings[6].ControllerValue + "]\n" + bindings[7].ControllerValue;
+                    ret = "VS\n[" + ApVspeedSetting.ControllerValue + "]\n" + PlaneVspeed.ControllerValue;
                     break;
             }
             return ret;
@@ -96,31 +95,31 @@
                 switch (actionParameter)
                 {
                     case "Altitude":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[8].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(AltSwitch.ControllerValue));
                         break;
                     case "Heading":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[9].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(HeadingSwitch.ControllerValue));
                         break;
                     case "Nav":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[10].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(NavSwitch.ControllerValue));
                         break;
                     case "Speed":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[11].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(SpeedSwitch.ControllerValue));
                         break;
                     case "AP":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[12].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(MasterSwitch.ControllerValue));
                         break;
                     case "Throttle":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[13].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(ThrottleSwitch.ControllerValue));
                         break;
                     case "VS Speed":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[14].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(VspeedSwitch.ControllerValue));
                         break;
                     case "Yaw Damper":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[15].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(binding15.ControllerValue));
                         break;
                     case "Back Course":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[16].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(BcSwitch.ControllerValue));
                         break;
                 }
                 bitmapBuilder.DrawText(actionParameter);
@@ -133,16 +132,16 @@
             switch (actionParameter)
             {
                 case "Altitude Encoder":
-                    bindings[0].SetControllerValue(ConvertTool.ApplyAdjustment(bindings[0].ControllerValue, ticks, -10000, 99900, 100));
+                    ApAltSetting.SetControllerValue(ConvertTool.ApplyAdjustment(ApAltSetting.ControllerValue, ticks, -10000, 99900, 100));
                     break;
                 case "Heading Encoder":
-                    bindings[2].SetControllerValue(ConvertTool.ApplyAdjustment(bindings[2].ControllerValue, ticks, 1, 360, 1, true));
+                    ApHdgSetting.SetControllerValue(ConvertTool.ApplyAdjustment(ApHdgSetting.ControllerValue, ticks, 1, 360, 1, true));
                     break;
                 case "Speed Encoder":
-                    bindings[4].SetControllerValue(ConvertTool.ApplyAdjustment(bindings[4].ControllerValue, ticks, 0, 2000, 1));
+                    ApSpeedSetting.SetControllerValue(ConvertTool.ApplyAdjustment(ApSpeedSetting.ControllerValue, ticks, 0, 2000, 1));
                     break;
                 case "VS Speed Encoder":
-                    bindings[6].SetControllerValue(ConvertTool.ApplyAdjustment(bindings[6].ControllerValue, ticks, -10000, 10000, 100));
+                    ApVspeedSetting.SetControllerValue(ConvertTool.ApplyAdjustment(ApVspeedSetting.ControllerValue, ticks, -10000, 10000, 100));
                     break;
             }
             EncoderActionNamesChanged();
@@ -152,45 +151,66 @@
             switch (actionParameter)
             {
                 case "Altitude":
-                    bindings[8].SetControllerValue(1);
+                    AltSwitch.SetControllerValue(1);
                     break;
                 case "Heading":
-                    bindings[9].SetControllerValue(1);
+                    HeadingSwitch.SetControllerValue(1);
                     break;
                 case "Nav":
-                    bindings[10].SetControllerValue(1);
+                    NavSwitch.SetControllerValue(1);
                     break;
                 case "Speed":
-                    bindings[11].SetControllerValue(1);
+                    SpeedSwitch.SetControllerValue(1);
                     break;
                 case "AP":
-                    bindings[12].SetControllerValue(1);
+                    MasterSwitch.SetControllerValue(1);
                     break;
                 case "Throttle":
-                    bindings[13].SetControllerValue(1);
+                    ThrottleSwitch.SetControllerValue(1);
                     break;
                 case "VS Speed":
-                    bindings[14].SetControllerValue(1);
+                    VspeedSwitch.SetControllerValue(1);
                     break;
                 case "Yaw Damper":
-                    bindings[15].SetControllerValue(1);
+                    binding15.SetControllerValue(1);
                     break;
                 case "Back Course":
-                    bindings[16].SetControllerValue(1);
+                    BcSwitch.SetControllerValue(1);
                     break;
                 case "Altitude Reset":
-                    bindings[0].SetControllerValue((long)(Math.Round(bindings[1].ControllerValue / 100d, 0) * 100));
+                    ApAltSetting.SetControllerValue((long)(Math.Round(PlaneAltitude.ControllerValue / 100d, 0) * 100));
                     break;
                 case "Heading Reset":
-                    bindings[2].SetControllerValue(bindings[3].ControllerValue);
+                    ApHdgSetting.SetControllerValue(PlaneHeading.ControllerValue);
                     break;
                 case "Speed Reset":
-                    bindings[4].SetControllerValue((long)(Math.Round(bindings[5].ControllerValue / 100d, 0) * 100));
+                    ApSpeedSetting.SetControllerValue((long)(Math.Round(PlaneSpeed.ControllerValue / 100d, 0) * 100));
                     break;
                 case "VS Speed Reset":
-                    bindings[6].SetControllerValue((long)(Math.Round(bindings[7].ControllerValue / 100d, 0) * 100));
+                    ApVspeedSetting.SetControllerValue((long)(Math.Round(PlaneVspeed.ControllerValue / 100d, 0) * 100));
                     break;
             }
         }
+
+        readonly Binding ApAltSetting;
+        readonly Binding PlaneAltitude;
+        readonly Binding ApHdgSetting;
+        readonly Binding PlaneHeading;
+        readonly Binding ApSpeedSetting;
+        readonly Binding PlaneSpeed;
+        readonly Binding ApVspeedSetting;
+        readonly Binding PlaneVspeed;
+        readonly Binding AltSwitch;
+        readonly Binding HeadingSwitch;
+        readonly Binding NavSwitch;
+        readonly Binding SpeedSwitch;
+        readonly Binding MasterSwitch;
+        readonly Binding ThrottleSwitch;
+        readonly Binding VspeedSwitch;
+
+        public Binding YdSwitch { get; }
+
+        readonly Binding binding15;
+        readonly Binding BcSwitch;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/folder/ATCDynamicFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/ATCDynamicFolder.cs
@@ -8,17 +8,17 @@
     {
         public ATCDynamicFolder() : base("ATC")
         {
-            bindings.Add(Register(BindingKeys.ATC_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_0_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_1_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_2_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_3_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_4_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_5_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_6_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_7_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_8_ATC_FOLDER));
-            bindings.Add(Register(BindingKeys.ATC_9_ATC_FOLDER));
+            OpenClose = Bind(BindingKeys.ATC_ATC_FOLDER);
+            Choice1 = Bind(BindingKeys.ATC_1_ATC_FOLDER);
+            Choice2 = Bind(BindingKeys.ATC_2_ATC_FOLDER);
+            Choice3 = Bind(BindingKeys.ATC_3_ATC_FOLDER);
+            Choice4 = Bind(BindingKeys.ATC_4_ATC_FOLDER);
+            Choice5 = Bind(BindingKeys.ATC_5_ATC_FOLDER);
+            Choice6 = Bind(BindingKeys.ATC_6_ATC_FOLDER);
+            Choice7 = Bind(BindingKeys.ATC_7_ATC_FOLDER);
+            Choice8 = Bind(BindingKeys.ATC_8_ATC_FOLDER);
+            Choice9 = Bind(BindingKeys.ATC_9_ATC_FOLDER);
+            Choice0 = Bind(BindingKeys.ATC_0_ATC_FOLDER);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.EncoderArea;
@@ -28,7 +28,6 @@
             return new[]
             {
                 CreateCommandName("Open/Close"),
-                CreateCommandName("0"),
                 CreateCommandName("1"),
                 CreateCommandName("2"),
                 CreateCommandName("3"),
@@ -37,7 +36,8 @@
                 CreateCommandName("6"),
                 CreateCommandName("7"),
                 CreateCommandName("8"),
-                CreateCommandName("9")
+                CreateCommandName("9"),
+                CreateCommandName("0")
             };
         }
 
@@ -49,39 +49,51 @@
             switch (actionParameter)
             {
                 case "Open/Close":
-                    bindings[0].SetControllerValue(1);
-                    break;
-                case "0":
-                    bindings[1].SetControllerValue(1);
+                    OpenClose.SetControllerValue(1);
                     break;
                 case "1":
-                    bindings[2].SetControllerValue(1);
+                    Choice1.SetControllerValue(1);
                     break;
                 case "2":
-                    bindings[3].SetControllerValue(1);
+                    Choice2.SetControllerValue(1);
                     break;
                 case "3":
-                    bindings[4].SetControllerValue(1);
+                    Choice3.SetControllerValue(1);
                     break;
                 case "4":
-                    bindings[5].SetControllerValue(1);
+                    Choice4.SetControllerValue(1);
                     break;
                 case "5":
-                    bindings[6].SetControllerValue(1);
+                    Choice5.SetControllerValue(1);
                     break;
                 case "6":
-                    bindings[7].SetControllerValue(1);
+                    Choice6.SetControllerValue(1);
                     break;
                 case "7":
-                    bindings[8].SetControllerValue(1);
+                    Choice7.SetControllerValue(1);
                     break;
                 case "8":
-                    bindings[9].SetControllerValue(1);
+                    Choice8.SetControllerValue(1);
                     break;
                 case "9":
-                    bindings[10].SetControllerValue(1);
+                    Choice9.SetControllerValue(1);
+                    break;
+                case "0":
+                    Choice0.SetControllerValue(1);
                     break;
             }
         }
+
+        readonly Binding OpenClose;
+        readonly Binding Choice1;
+        readonly Binding Choice2;
+        readonly Binding Choice3;
+        readonly Binding Choice4;
+        readonly Binding Choice5;
+        readonly Binding Choice6;
+        readonly Binding Choice7;
+        readonly Binding Choice8;
+        readonly Binding Choice9;
+        readonly Binding Choice0;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/folder/AirlinerDynamicFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/AirlinerDynamicFolder.cs
@@ -9,28 +9,28 @@
     {
         public AirlinerDynamicFolder() : base("Autopilot")
         {
-            bindings.Add(ApAltSetting = Register(BindingKeys.AP_ALT));
-            bindings.Add(PlaneAltitude = Register(BindingKeys.ALT));
-            bindings.Add(ApHdgSetting = Register(BindingKeys.AP_HEADING));
-            bindings.Add(PlaneHeading = Register(BindingKeys.HEADING));
-            bindings.Add(ApSpeedSetting = Register(BindingKeys.AP_SPEED));
-            bindings.Add(PlaneSpeed = Register(BindingKeys.SPEED));
-            bindings.Add(ApVspeedSetting = Register(BindingKeys.AP_VSPEED));
-            bindings.Add(PlaneVspeed = Register(BindingKeys.VSPEED));
+            ApAltSetting = Bind(BindingKeys.AP_ALT);
+            PlaneAltitude = Bind(BindingKeys.ALT);
+            ApHdgSetting = Bind(BindingKeys.AP_HEADING);
+            PlaneHeading = Bind(BindingKeys.HEADING);
+            ApSpeedSetting = Bind(BindingKeys.AP_SPEED);
+            PlaneSpeed = Bind(BindingKeys.SPEED);
+            ApVspeedSetting = Bind(BindingKeys.AP_VSPEED);
+            PlaneVspeed = Bind(BindingKeys.VSPEED);
 
-            bindings.Add(FdSwitch = Register(BindingKeys.AP_FD_SWITCH));
-            bindings.Add(AltSwitch = Register(BindingKeys.AP_ALT_SWITCH));
-            bindings.Add(MasterSwitch = Register(BindingKeys.AP_MASTER_SWITCH));
-            bindings.Add(NavSwitch = Register(BindingKeys.AP_NAV_SWITCH));
-            bindings.Add(FlcSwitch = Register(BindingKeys.AP_FLC_SWITCH));
-            bindings.Add(AprSwitch = Register(BindingKeys.AP_APP_SWITCH));
-            bindings.Add(LocSwitch = Register(BindingKeys.AP_LOC_SWITCH));
-            bindings.Add(SpeedSwitch = Register(BindingKeys.AP_SPEED_SWITCH));
-            bindings.Add(HeadingSwitch = Register(BindingKeys.AP_HEAD_SWITCH));
-            bindings.Add(ThrottleSwitch = Register(BindingKeys.AP_THROTTLE_SWITCH));
-            bindings.Add(VspeedSwitch = Register(BindingKeys.AP_VSPEED_SWITCH));
-            bindings.Add(YdSwitch = Register(BindingKeys.AP_YAW_DAMPER_SWITCH));
-            bindings.Add(BcSwitch = Register(BindingKeys.AP_BC_SWITCH));
+            MasterSwitch = Bind(BindingKeys.AP_MASTER_SWITCH);
+            FdSwitch = Bind(BindingKeys.AP_FD_SWITCH);
+            AltSwitch = Bind(BindingKeys.AP_ALT_SWITCH);
+            HeadingSwitch = Bind(BindingKeys.AP_HEAD_SWITCH);
+            NavSwitch = Bind(BindingKeys.AP_NAV_SWITCH);
+            FlcSwitch = Bind(BindingKeys.AP_FLC_SWITCH);
+            AprSwitch = Bind(BindingKeys.AP_APP_SWITCH);
+            LocSwitch = Bind(BindingKeys.AP_LOC_SWITCH);
+            SpeedSwitch = Bind(BindingKeys.AP_SPEED_SWITCH);
+            ThrottleSwitch = Bind(BindingKeys.AP_THROTTLE_SWITCH);
+            VspeedSwitch = Bind(BindingKeys.AP_VSPEED_SWITCH);
+            YdSwitch = Bind(BindingKeys.AP_YAW_DAMPER_SWITCH);
+            BcSwitch = Bind(BindingKeys.AP_BC_SWITCH);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.None;
@@ -59,6 +59,7 @@
                 NavigateRightActionName
             };
         }
+
         public override IEnumerable<string> GetButtonPressActionNames(DeviceType deviceType)
         {
             return new[]
@@ -66,7 +67,7 @@
                 NavigateUpActionName,
                 CreateCommandName("FD"),
                 CreateCommandName("AP"),
-                CreateCommandName("Yaw Damp"),
+                CreateCommandName("Yaw Damper"),
 
                 CreateCommandName("Altitude"),
                 CreateCommandName("FLC"),
@@ -79,7 +80,7 @@
                 CreateCommandName("VSpeed"),
 
                 CreateCommandName("Throttle"),
-                CreateCommandName("Back Crs"),
+                CreateCommandName("Back Course"),
             };
         }
 
@@ -103,6 +104,7 @@
             }
             return ret;
         }
+
         public override BitmapImage GetCommandImage(string actionParameter, PluginImageSize imageSize)
         {
             using (var bitmapBuilder = new BitmapBuilder(imageSize))
@@ -142,14 +144,15 @@
                     case "VSpeed":
                         bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(VspeedSwitch.ControllerValue));
                         break;
-                    case "Yaw Damp":
+                    case "Yaw Damper":
                         bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(YdSwitch.ControllerValue));
                         break;
-                    case "Back Crs":
+                    case "Back Course":
                         bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(BcSwitch.ControllerValue));
                         break;
                 }
-                bitmapBuilder.DrawText(actionParameter);
+                bitmapBuilder.Translate(0, -10);
+                bitmapBuilder.DrawText(actionParameter.Replace(' ', '\n'));
                 return bitmapBuilder.ToImage();
             }
         }
@@ -210,10 +213,10 @@
                 case "VSpeed":
                     VspeedSwitch.SetControllerValue(1);
                     break;
-                case "Yaw Damp":
+                case "Yaw Damper":
                     YdSwitch.SetControllerValue(1);
                     break;
-                case "Back Crs":
+                case "Back Course":
                     BcSwitch.SetControllerValue(1);
                     break;
                 case "Altitude Reset":

--- a/MsfsPlugin/MsfsPlugin/folder/CockpitViewFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/CockpitViewFolder.cs
@@ -16,20 +16,20 @@
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.EncoderArea;
 
         public override IEnumerable<string> GetButtonPressActionNames(DeviceType deviceType) => new[]
-            {
-                CreateCommandName("1"),
-                CreateCommandName("2"),
-                CreateCommandName("3"),
-                CreateCommandName("4"),
-                CreateCommandName("5"),
-                CreateCommandName("6"),
-                CreateCommandName("7"),
-                CreateCommandName("8"),
-                CreateCommandName("9"),
-                CreateCommandName("0"),
-                CreateCommandName(FixedCustom),
-                CreateCommandName(SetMode),
-            };
+        {
+            CreateCommandName("1"),
+            CreateCommandName("2"),
+            CreateCommandName("3"),
+            CreateCommandName("4"),
+            CreateCommandName("5"),
+            CreateCommandName("6"),
+            CreateCommandName("7"),
+            CreateCommandName("8"),
+            CreateCommandName("9"),
+            CreateCommandName("0"),
+            CreateCommandName(FixedCustom),
+            CreateCommandName(SetMode),
+        };
 
         public override string GetCommandDisplayName(string actionParameter, PluginImageSize imageSize) => actionParameter;
 

--- a/MsfsPlugin/MsfsPlugin/folder/ComDynamicFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/ComDynamicFolder.cs
@@ -9,24 +9,14 @@
     {
         public ComDynamicFolder() : base("COM")
         {
-            bindings.Add(Register(BindingKeys.COM1_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.COM2_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.COM3_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.COM1_ACTIVE_FREQUENCY_TYPE));
-            bindings.Add(Register(BindingKeys.COM2_ACTIVE_FREQUENCY_TYPE));
-            bindings.Add(Register(BindingKeys.COM3_ACTIVE_FREQUENCY_TYPE));
-            bindings.Add(Register(BindingKeys.COM1_STATUS));
-            bindings.Add(Register(BindingKeys.COM2_STATUS));
-            bindings.Add(Register(BindingKeys.COM3_STATUS));
-            bindings.Add(Register(BindingKeys.COM1_AVAILABLE));
-            bindings.Add(Register(BindingKeys.COM2_AVAILABLE));
-            bindings.Add(Register(BindingKeys.COM3_AVAILABLE));
-            bindings.Add(Register(BindingKeys.COM1_STBY));
-            bindings.Add(Register(BindingKeys.COM2_STBY));
-            bindings.Add(Register(BindingKeys.COM3_STBY));
-            bindings.Add(Register(BindingKeys.COM1_RADIO_SWAP));
-            bindings.Add(Register(BindingKeys.COM2_RADIO_SWAP));
-            bindings.Add(Register(BindingKeys.COM3_RADIO_SWAP));
+            com1Active = Bind(BindingKeys.COM1_ACTIVE_FREQUENCY);
+            com2Active = Bind(BindingKeys.COM2_ACTIVE_FREQUENCY);
+            com1Available = Bind(BindingKeys.COM1_AVAILABLE);
+            com2Available = Bind(BindingKeys.COM2_AVAILABLE);
+            com1Stby = Bind(BindingKeys.COM1_STBY);
+            com2Stby = Bind(BindingKeys.COM2_STBY);
+            com1Swap = Bind(BindingKeys.COM1_RADIO_SWAP);
+            com2Swap = Bind(BindingKeys.COM2_RADIO_SWAP);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.None;
@@ -77,17 +67,17 @@
             switch (actionParameter)
             {
                 case "COM1 Int Encoder":
-                    ret = "COM1\n" + Math.Truncate(bindings[12].ControllerValue / 1000000f) + ".";
+                    ret = "COM1\n" + Math.Truncate(com1Stby.ControllerValue / 1000000f) + ".";
                     break;
                 case "COM1 Float Encoder":
-                    var com1dbl = Math.Round(bindings[12].ControllerValue / 1000000f - Math.Truncate(bindings[12].ControllerValue / 1000000f), 3).ToString();
+                    var com1dbl = Math.Round(com1Stby.ControllerValue / 1000000f - Math.Truncate(com1Stby.ControllerValue / 1000000f), 3).ToString();
                     ret = "COM1\n" + (com1dbl.Length > 2 ? com1dbl.Substring(2) : com1dbl).PadRight(3, '0');
                     break;
                 case "COM2 Int Encoder":
-                    ret = "COM2\n" + Math.Truncate(bindings[13].ControllerValue / 1000000f) + ".";
+                    ret = "COM2\n" + Math.Truncate(com2Stby.ControllerValue / 1000000f) + ".";
                     break;
                 case "COM2 Float Encoder":
-                    var com2dbl = Math.Round(bindings[13].ControllerValue / 1000000f - Math.Truncate(bindings[13].ControllerValue / 1000000f), 3).ToString();
+                    var com2dbl = Math.Round(com2Stby.ControllerValue / 1000000f - Math.Truncate(com2Stby.ControllerValue / 1000000f), 3).ToString();
                     ret = "COM2\n" + (com2dbl.Length > 2 ? com2dbl.Substring(2) : com2dbl).PadRight(3, '0');
                     break;
             }
@@ -101,36 +91,36 @@
                 switch (actionParameter)
                 {
                     case "COM1 Active Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[9].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[0].ControllerValue == 0 ? "0" : bindings[0].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText((com1Active.ControllerValue == 0 ? "0" : com1Active.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
                         break;
                     case "COM1 Active Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[9].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[0].ControllerValue == 0 ? "0" : bindings[0].ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText(com1Active.ControllerValue == 0 ? "0" : com1Active.ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
                         break;
                     case "COM1 Standby Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[9].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[12].ControllerValue == 0 ? "0" : bindings[12].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText((com1Stby.ControllerValue == 0 ? "0" : com1Stby.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
                         break;
                     case "COM1 Standby Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[9].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[12].ControllerValue == 0 ? "0" : bindings[12].ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText(com1Stby.ControllerValue == 0 ? "0" : com1Stby.ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
                         break;
                     case "COM2 Active Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[10].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[1].ControllerValue == 0 ? "0" : bindings[1].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText((com2Active.ControllerValue == 0 ? "0" : com2Active.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
                         break;
                     case "COM2 Active Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[10].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[1].ControllerValue == 0 ? "0" : bindings[1].ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText(com2Active.ControllerValue == 0 ? "0" : com2Active.ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
                         break;
                     case "COM2 Standby Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[10].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[13].ControllerValue == 0 ? "0" : bindings[13].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText((com2Stby.ControllerValue == 0 ? "0" : com2Stby.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
                         break;
                     case "COM2 Standby Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[10].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[13].ControllerValue == 0 ? "0" : bindings[13].ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText(com2Stby.ControllerValue == 0 ? "0" : com2Stby.ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
                         break;
 
                 }
@@ -150,7 +140,7 @@
                 case "COM1 Standby Float":
                 case "COM1 Int Reset":
                 case "COM1 Float Reset":
-                    bindings[15].SetControllerValue(1);
+                    com1Swap.SetControllerValue(1);
                     break;
                 case "COM2 Active":
                 case "COM2 Active Int":
@@ -160,7 +150,7 @@
                 case "COM2 Standby Float":
                 case "COM2 Int Reset":
                 case "COM2 Float Reset":
-                    bindings[16].SetControllerValue(1);
+                    com2Swap.SetControllerValue(1);
                     break;
             }
         }
@@ -170,16 +160,16 @@
             switch (actionParameter)
             {
                 case "COM1 Int Encoder":
-                    bindings[12].SetControllerValue(adjuster.IncrIntValue(bindings[12].ControllerValue, ticks));
+                    IncrIntValue(com1Stby, ticks);
                     break;
                 case "COM1 Float Encoder":
-                    bindings[12].SetControllerValue(adjuster.IncrDecimalValue(bindings[12].ControllerValue, ticks));
+                    IncrDecimalValue(com1Stby, ticks);
                     break;
                 case "COM2 Int Encoder":
-                    bindings[13].SetControllerValue(adjuster.IncrIntValue(bindings[13].ControllerValue, ticks));
+                    IncrIntValue(com2Stby, ticks);
                     break;
                 case "COM2 Float Encoder":
-                    bindings[13].SetControllerValue(adjuster.IncrDecimalValue(bindings[13].ControllerValue, ticks));
+                    IncrDecimalValue(com2Stby, ticks);
                     break;
 
             }
@@ -187,6 +177,19 @@
             ButtonActionNamesChanged();
         }
 
-        readonly DecimalValueAdjuster adjuster = new DecimalValueAdjuster(118, 136, 0, 995, 5, 1000000);
+        private void IncrIntValue(Binding binding, int ticks) => binding.SetControllerValue(adjuster.IncrIntValue(binding.ControllerValue, ticks));
+
+        private void IncrDecimalValue(Binding binding, int ticks) => binding.SetControllerValue(adjuster.IncrDecimalValue(binding.ControllerValue, ticks));
+
+        private readonly DecimalValueAdjuster adjuster = new DecimalValueAdjuster(118, 136, 0, 995, 5, 1000000);
+
+        private readonly Binding com1Active;
+        private readonly Binding com2Active;
+        private readonly Binding com1Available;
+        private readonly Binding com2Available;
+        private readonly Binding com1Stby;
+        private readonly Binding com2Stby;
+        private readonly Binding com1Swap;
+        private readonly Binding com2Swap;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/folder/ComDynamicSFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/ComDynamicSFolder.cs
@@ -7,17 +7,16 @@
 
     public class ComDynamicSFolder : DefaultFolder
     {
-        private bool isCom1active = true;
         public ComDynamicSFolder() : base("COM (for S)")
         {
-            bindings.Add(Register(BindingKeys.COM1_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.COM2_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.COM1_STBY));
-            bindings.Add(Register(BindingKeys.COM2_STBY));
-            bindings.Add(Register(BindingKeys.COM1_AVAILABLE));
-            bindings.Add(Register(BindingKeys.COM2_AVAILABLE));
-            bindings.Add(Register(BindingKeys.COM1_RADIO_SWAP));
-            bindings.Add(Register(BindingKeys.COM2_RADIO_SWAP));
+            com1Active = Bind(BindingKeys.COM1_ACTIVE_FREQUENCY);
+            com2Active = Bind(BindingKeys.COM2_ACTIVE_FREQUENCY);
+            com1Available = Bind(BindingKeys.COM1_AVAILABLE);
+            com2Available = Bind(BindingKeys.COM2_AVAILABLE);
+            com1Stby = Bind(BindingKeys.COM1_STBY);
+            com2Stby = Bind(BindingKeys.COM2_STBY);
+            com1Swap = Bind(BindingKeys.COM1_RADIO_SWAP);
+            com2Swap = Bind(BindingKeys.COM2_RADIO_SWAP);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.EncoderArea;
@@ -57,23 +56,24 @@
                 CreateCommandName("Float Reset"),
             };
         }
+
         public override string GetAdjustmentDisplayName(string actionParameter, PluginImageSize imageSize)
         {
-
-            var bindingIndex = isCom1active ? 2 : 3;
+            var binding = isCom1active ? com1Stby : com2Stby;
             var ret = "";
             switch (actionParameter)
             {
                 case "Int":
-                    ret = "COM\n" + Math.Truncate(bindings[bindingIndex].ControllerValue / 1000000f) + ".";
+                    ret = "COM\n" + Math.Truncate(binding.ControllerValue / 1000000f) + ".";
                     break;
                 case "Float":
-                    var com1dbl = Math.Round(bindings[bindingIndex].ControllerValue / 1000000f - Math.Truncate(bindings[bindingIndex].ControllerValue / 1000000f), 3).ToString();
+                    var com1dbl = Math.Round(binding.ControllerValue / 1000000f - Math.Truncate(binding.ControllerValue / 1000000f), 3).ToString();
                     ret = "COM\n" + (com1dbl.Length > 2 ? com1dbl.Substring(2) : com1dbl).PadRight(3, '0');
                     break;
             }
             return ret;
         }
+
         public override BitmapImage GetCommandImage(string actionParameter, PluginImageSize imageSize)
         {
             using (var bitmapBuilder = new BitmapBuilder(imageSize))
@@ -81,44 +81,44 @@
                 switch (actionParameter)
                 {
                     case "COM1":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
                         bitmapBuilder.DrawText(isCom1active ? "=> COM1" : "COM1");
                         break;
                     case "COM2":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
                         bitmapBuilder.DrawText(!isCom1active ? "=> COM2" : "COM2");
                         break;
                     case "COM1 Active Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[0].ControllerValue == 0 ? "0" : bindings[0].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText((com1Active.ControllerValue == 0 ? "0" : com1Active.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
                         break;
                     case "COM1 Active Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[0].ControllerValue == 0 ? "0" : bindings[0].ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText(com1Active.ControllerValue == 0 ? "0" : com1Active.ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
                         break;
                     case "COM1 Standby Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[2].ControllerValue == 0 ? "0" : bindings[2].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText((com1Stby.ControllerValue == 0 ? "0" : com1Stby.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
                         break;
                     case "COM1 Standby Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[2].ControllerValue == 0 ? "0" : bindings[2].ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com1Available.MsfsValue));
+                        bitmapBuilder.DrawText(com1Stby.ControllerValue == 0 ? "0" : com1Stby.ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
                         break;
                     case "COM2 Active Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[1].ControllerValue == 0 ? "0" : bindings[1].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText((com2Active.ControllerValue == 0 ? "0" : com2Active.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
                         break;
                     case "COM2 Active Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[1].ControllerValue == 0 ? "0" : bindings[1].ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText(com2Active.ControllerValue == 0 ? "0" : com2Active.ControllerValue.ToString().Substring(3, 3), ImageTool.Green, 40);
                         break;
                     case "COM2 Standby Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[3].ControllerValue == 0 ? "0" : bindings[3].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText((com2Stby.ControllerValue == 0 ? "0" : com2Stby.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
                         break;
                     case "COM2 Standby Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[3].ControllerValue == 0 ? "0" : bindings[3].ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(com2Available.MsfsValue));
+                        bitmapBuilder.DrawText(com2Stby.ControllerValue == 0 ? "0" : com2Stby.ControllerValue.ToString().Substring(3, 3), ImageTool.Yellow, 40);
                         break;
                 }
                 return bitmapBuilder.ToImage();
@@ -139,44 +139,55 @@
                 case "COM1 Active Float":
                 case "COM1 Standby Int":
                 case "COM1 Standby Float":
-                    bindings[6].SetControllerValue(1);
+                    com1Swap.SetControllerValue(1);
                     break;
                 case "COM2 Active Int":
                 case "COM2 Active Float":
                 case "COM2 Standby Int":
                 case "COM2 Standby Float":
-                    bindings[7].SetControllerValue(1);
+                    com2Swap.SetControllerValue(1);
                     break;
                 case "Int Reset":
                 case "Float Reset":
                     if (isCom1active)
-                        bindings[6].SetControllerValue(1);
+                        com1Swap.SetControllerValue(1);
                     else
-                        bindings[7].SetControllerValue(1);
+                        com2Swap.SetControllerValue(1);
                     break;
             }
         }
 
         public override void ApplyAdjustment(string actionParameter, int ticks)
         {
-            var bindingIndex = isCom1active ? 2 : 3;
+            var binding = isCom1active ? com1Stby : com2Stby;
             switch (actionParameter)
             {
                 case "Int":
-                    var com1int = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(0, 3));
-                    var com1dbl = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(3, 3));
+                    var com1int = int.Parse(binding.ControllerValue.ToString().Substring(0, 3));
+                    var com1dbl = int.Parse(binding.ControllerValue.ToString().Substring(3, 3));
                     var newInt = ConvertTool.ApplyAdjustment(com1int, ticks, 118, 136, 1, true);
-                    bindings[bindingIndex].SetControllerValue(newInt * 1000000 + com1dbl * 1000);
+                    binding.SetControllerValue(newInt * 1000000 + com1dbl * 1000);
                     break;
                 case "Float":
-                    var com1dbl1 = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(3, 3));
-                    var com1int1 = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(0, 3));
+                    var com1dbl1 = int.Parse(binding.ControllerValue.ToString().Substring(3, 3));
+                    var com1int1 = int.Parse(binding.ControllerValue.ToString().Substring(0, 3));
                     var newFloat = ConvertTool.ApplyAdjustment(com1dbl1, ticks, 0, 995, 5, true);
-                    bindings[bindingIndex].SetControllerValue(com1int1 * 1000000 + newFloat * 1000);
+                    binding.SetControllerValue(com1int1 * 1000000 + newFloat * 1000);
                     break;
             }
             EncoderActionNamesChanged();
             ButtonActionNamesChanged();
         }
+
+        private bool isCom1active = true;
+
+        private readonly Binding com1Active;
+        private readonly Binding com2Active;
+        private readonly Binding com1Stby;
+        private readonly Binding com2Stby;
+        private readonly Binding com1Available;
+        private readonly Binding com2Available;
+        private readonly Binding com1Swap;
+        private readonly Binding com2Swap;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/folder/DefaultFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/DefaultFolder.cs
@@ -1,29 +1,22 @@
 ﻿namespace Loupedeck.MsfsPlugin.folder
 {
-    using System.Collections.Generic;
-
     using Loupedeck.MsfsPlugin;
+    using Loupedeck.MsfsPlugin.tools;
 
     public abstract class DefaultFolder : PluginDynamicFolder, INotifiable
     {
-        protected readonly List<Binding> bindings = new List<Binding>();
-
         protected DefaultFolder(string displayName)
         {
             DisplayName = displayName;
             GroupName = "Folder";
+            entity = new CommonEntity();
             MsfsData.Instance.Register(this);
         }
 
-        public void Notify()
-        {
-            foreach (Binding binding in bindings)
-            {
-                if (binding.HasMSFSChanged())
-                    binding.Reset();
-            }
-        }
+        protected Binding Bind(BindingKeys key) => entity.Bind(key);
 
-        protected static Binding Register(BindingKeys key) => MsfsData.Instance.Register(key);
+        public void Notify() => entity.Notify();
+
+        readonly CommonEntity entity;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/folder/LightsDynamicFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/LightsDynamicFolder.cs
@@ -9,20 +9,20 @@
     {
         public LightsDynamicFolder() : base("Lights")
         {
-            bindings.Add(Register(BindingKeys.LIGHT_NAV));
-            bindings.Add(Register(BindingKeys.LIGHT_BEACON));
-            bindings.Add(Register(BindingKeys.LIGHT_LANDING));
-            bindings.Add(Register(BindingKeys.LIGHT_TAXI));
-            bindings.Add(Register(BindingKeys.LIGHT_STROBE));
-            bindings.Add(Register(BindingKeys.LIGHT_INSTRUMENT));
-            bindings.Add(Register(BindingKeys.LIGHT_RECOG));
-            bindings.Add(Register(BindingKeys.LIGHT_WING));
-            bindings.Add(Register(BindingKeys.LIGHT_LOGO));
-            bindings.Add(Register(BindingKeys.LIGHT_CABIN));
-            bindings.Add(Register(BindingKeys.LIGHT_PEDESTAL));
-            bindings.Add(Register(BindingKeys.LIGHT_GLARESHIELD));
-            bindings.Add(Register(BindingKeys.FLASHLIGHT));
-            bindings.Add(Register(BindingKeys.LIGHT_ALL_SWITCH));
+            nav = Bind(BindingKeys.LIGHT_NAV);
+            beacon = Bind(BindingKeys.LIGHT_BEACON);
+            landing = Bind(BindingKeys.LIGHT_LANDING);
+            taxi = Bind(BindingKeys.LIGHT_TAXI);
+            strobe = Bind(BindingKeys.LIGHT_STROBE);
+            instrument = Bind(BindingKeys.LIGHT_INSTRUMENT);
+            recognition = Bind(BindingKeys.LIGHT_RECOG);
+            wing = Bind(BindingKeys.LIGHT_WING);
+            logo = Bind(BindingKeys.LIGHT_LOGO);
+            cabin = Bind(BindingKeys.LIGHT_CABIN);
+            pedestal = Bind(BindingKeys.LIGHT_PEDESTAL);
+            glareshield = Bind(BindingKeys.LIGHT_GLARESHIELD);
+            flash = Bind(BindingKeys.FLASHLIGHT);
+            allLights = Bind(BindingKeys.LIGHT_ALL_SWITCH);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.None;
@@ -54,43 +54,43 @@
                 switch (actionParameter)
                 {
                     case "Navigation":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[0].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(nav.ControllerValue));
                         break;
                     case "Beacon":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[1].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(beacon.ControllerValue));
                         break;
                     case "Landing":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[2].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(landing.ControllerValue));
                         break;
                     case "Taxi":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[3].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(taxi.ControllerValue));
                         break;
                     case "Strobes":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[4].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(strobe.ControllerValue));
                         break;
                     case "Instruments":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[5].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(instrument.ControllerValue));
                         break;
                     case "Recognition":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[6].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(recognition.ControllerValue));
                         break;
                     case "Wing":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[7].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(wing.ControllerValue));
                         break;
                     case "Logo":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[8].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(logo.ControllerValue));
                         break;
                     case "Cabin":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[9].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(cabin.ControllerValue));
                         break;
                     case "Pedestal":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[10].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(pedestal.ControllerValue));
                         break;
                     case "Glareshield":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[11].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(glareshield.ControllerValue));
                         break;
                     case "Flashlight":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(bindings[12].ControllerValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetOnOffImage(flash.ControllerValue));
                         break;
                     case "All":
                         break;
@@ -107,49 +107,64 @@
             switch (actionParameter)
             {
                 case "Navigation":
-                    bindings[0].SetControllerValue(1);
+                    nav.SetControllerValue(1);
                     break;
                 case "Beacon":
-                    bindings[1].SetControllerValue(1);
+                    beacon.SetControllerValue(1);
                     break;
                 case "Landing":
-                    bindings[2].SetControllerValue(1);
+                    landing.SetControllerValue(1);
                     break;
                 case "Taxi":
-                    bindings[3].SetControllerValue(1);
+                    taxi.SetControllerValue(1);
                     break;
                 case "Strobes":
-                    bindings[4].SetControllerValue(1);
+                    strobe.SetControllerValue(1);
                     break;
                 case "Instruments":
-                    bindings[5].SetControllerValue(1);
+                    instrument.SetControllerValue(1);
                     break;
                 case "Recognition":
-                    bindings[6].SetControllerValue(1);
+                    recognition.SetControllerValue(1);
                     break;
                 case "Wing":
-                    bindings[7].SetControllerValue(1);
+                    wing.SetControllerValue(1);
                     break;
                 case "Logo":
-                    bindings[8].SetControllerValue(1);
+                    logo.SetControllerValue(1);
                     break;
                 case "Cabin":
-                    bindings[9].SetControllerValue(1);
+                    cabin.SetControllerValue(1);
                     break;
                 case "Pedestal":
-                    bindings[10].SetControllerValue(1);
+                    pedestal.SetControllerValue(1);
                     break;
                 case "Glareshield":
-                    bindings[11].SetControllerValue(1);
+                    glareshield.SetControllerValue(1);
                     break;
                 case "Flashlight":
-                    bindings[12].SetControllerValue(1);
+                    flash.SetControllerValue(1);
                     break;
                 case "All":
-                    bindings[13].SetControllerValue(1);
+                    allLights.SetControllerValue(1);
                     break;
 
             }
         }
+
+        readonly Binding nav;
+        readonly Binding beacon;
+        readonly Binding landing;
+        readonly Binding taxi;
+        readonly Binding strobe;
+        readonly Binding instrument;
+        readonly Binding recognition;
+        readonly Binding wing;
+        readonly Binding logo;
+        readonly Binding cabin;
+        readonly Binding pedestal;
+        readonly Binding glareshield;
+        readonly Binding flash;
+        readonly Binding allLights;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/folder/NavDynamicFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/NavDynamicFolder.cs
@@ -8,19 +8,19 @@
     {
         public NavDynamicFolder() : base("NAV")
         {
-            bindings.Add(Nav1ActiveFreq = Register(BindingKeys.NAV1_ACTIVE_FREQUENCY));
-            bindings.Add(Nav2ActiveFreq = Register(BindingKeys.NAV2_ACTIVE_FREQUENCY));
-            bindings.Add(Nav1Available = Register(BindingKeys.NAV1_AVAILABLE));
-            bindings.Add(Nav2Available = Register(BindingKeys.NAV2_AVAILABLE));
-            bindings.Add(Nav1StandbyFreq = Register(BindingKeys.NAV1_STBY_FREQUENCY));
-            bindings.Add(Nav2StandbyFreq = Register(BindingKeys.NAV2_STBY_FREQUENCY));
-            bindings.Add(Nav1Swap = Register(BindingKeys.NAV1_RADIO_SWAP));
-            bindings.Add(Nav2Swap = Register(BindingKeys.NAV2_RADIO_SWAP));
-            bindings.Add(AdfActiveFreq = Register(BindingKeys.ADF_ACTIVE_FREQUENCY));
-            bindings.Add(AdfStandbyFreq = Register(BindingKeys.ADF_STBY_FREQUENCY));
-            bindings.Add(AdfAvail = Register(BindingKeys.ADF1_AVAILABLE));
-            bindings.Add(AdfStbyAvail = Register(BindingKeys.ADF1_STBY_AVAILABLE));
-            bindings.Add(AdfSwap = Register(BindingKeys.ADF_RADIO_SWAP));
+            Nav1ActiveFreq = Bind(BindingKeys.NAV1_ACTIVE_FREQUENCY);
+            Nav2ActiveFreq = Bind(BindingKeys.NAV2_ACTIVE_FREQUENCY);
+            Nav1Available = Bind(BindingKeys.NAV1_AVAILABLE);
+            Nav2Available = Bind(BindingKeys.NAV2_AVAILABLE);
+            Nav1StandbyFreq = Bind(BindingKeys.NAV1_STBY_FREQUENCY);
+            Nav2StandbyFreq = Bind(BindingKeys.NAV2_STBY_FREQUENCY);
+            Nav1Swap = Bind(BindingKeys.NAV1_RADIO_SWAP);
+            Nav2Swap = Bind(BindingKeys.NAV2_RADIO_SWAP);
+            AdfActiveFreq = Bind(BindingKeys.ADF_ACTIVE_FREQUENCY);
+            AdfStandbyFreq = Bind(BindingKeys.ADF_STBY_FREQUENCY);
+            AdfAvail = Bind(BindingKeys.ADF1_AVAILABLE);
+            AdfStbyAvail = Bind(BindingKeys.ADF1_STBY_AVAILABLE);
+            AdfSwap = Bind(BindingKeys.ADF_RADIO_SWAP);
         }
 
         // Plane                      Variable containing active frequency       Variable containing "other" freq     "other" frequency shown?  Swapping event

--- a/MsfsPlugin/MsfsPlugin/folder/NavDynamicSFolder.cs
+++ b/MsfsPlugin/MsfsPlugin/folder/NavDynamicSFolder.cs
@@ -7,17 +7,16 @@
 
     public class NavDynamicSFolder : DefaultFolder
     {
-        private bool isVar1Active = true;
         public NavDynamicSFolder() : base("NAV (for S)")
         {
-            bindings.Add(Register(BindingKeys.NAV1_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.NAV2_ACTIVE_FREQUENCY));
-            bindings.Add(Register(BindingKeys.NAV1_STBY_FREQUENCY));
-            bindings.Add(Register(BindingKeys.NAV2_STBY_FREQUENCY));
-            bindings.Add(Register(BindingKeys.NAV1_AVAILABLE));
-            bindings.Add(Register(BindingKeys.NAV2_AVAILABLE));
-            bindings.Add(Register(BindingKeys.NAV1_RADIO_SWAP));
-            bindings.Add(Register(BindingKeys.NAV2_RADIO_SWAP));
+            Nav1ActiveFreq = Bind(BindingKeys.NAV1_ACTIVE_FREQUENCY);
+            Nav2ActiveFreq = Bind(BindingKeys.NAV2_ACTIVE_FREQUENCY);
+            Nav1StandbyFreq = Bind(BindingKeys.NAV1_STBY_FREQUENCY);
+            Nav2StandbyFreq = Bind(BindingKeys.NAV2_STBY_FREQUENCY);
+            Nav1Available = Bind(BindingKeys.NAV1_AVAILABLE);
+            Nav2Available = Bind(BindingKeys.NAV2_AVAILABLE);
+            Nav1Swap = Bind(BindingKeys.NAV1_RADIO_SWAP);
+            Nav2Swap = Bind(BindingKeys.NAV2_RADIO_SWAP);
         }
 
         public override PluginDynamicFolderNavigation GetNavigationArea(DeviceType _) => PluginDynamicFolderNavigation.EncoderArea;
@@ -59,15 +58,15 @@
 
         public override string GetAdjustmentDisplayName(string actionParameter, PluginImageSize imageSize)
         {
-            var bindingIndex = isVar1Active ? 2 : 3;
+            var binding = isVar1Active ? Nav1StandbyFreq : Nav2StandbyFreq;
             var ret = "";
             switch (actionParameter)
             {
                 case "Int":
-                    ret = "NAV\n" + Math.Truncate(bindings[bindingIndex].ControllerValue / 1000000f) + ".";
+                    ret = "NAV\n" + Math.Truncate(binding.ControllerValue / 1000000f) + ".";
                     break;
                 case "Float":
-                    var var1dbl = Math.Round(bindings[bindingIndex].ControllerValue / 1000000f - Math.Truncate(bindings[bindingIndex].ControllerValue / 1000000f), 3).ToString();
+                    var var1dbl = Math.Round(binding.ControllerValue / 1000000f - Math.Truncate(binding.ControllerValue / 1000000f), 3).ToString();
                     ret = "NAV\n" + (var1dbl.Length > 2 ? var1dbl.Substring(2) : var1dbl).PadRight(2, '0');
                     break;
             }
@@ -81,44 +80,44 @@
                 switch (actionParameter)
                 {
                     case "NAV1":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav1Available.MsfsValue));
                         bitmapBuilder.DrawText(isVar1Active ? "=> NAV1" : "NAV1");
                         break;
                     case "NAV2":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav2Available.MsfsValue));
                         bitmapBuilder.DrawText(!isVar1Active ? "=> NAV2" : "NAV2");
                         break;
                     case "NAV1 Active Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[0].ControllerValue == 0 ? "0" : bindings[0].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav1Available.MsfsValue));
+                        bitmapBuilder.DrawText((Nav1ActiveFreq.ControllerValue == 0 ? "0" : Nav1ActiveFreq.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
                         break;
                     case "NAV1 Active Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[0].ControllerValue == 0 ? "0" : bindings[0].ControllerValue.ToString().Substring(3, 2), ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav1Available.MsfsValue));
+                        bitmapBuilder.DrawText(Nav1ActiveFreq.ControllerValue == 0 ? "0" : Nav1ActiveFreq.ControllerValue.ToString().Substring(3, 2), ImageTool.Green, 40);
                         break;
                     case "NAV1 Standby Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[2].ControllerValue == 0 ? "0" : bindings[2].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav1Available.MsfsValue));
+                        bitmapBuilder.DrawText((Nav1StandbyFreq.ControllerValue == 0 ? "0" : Nav1StandbyFreq.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
                         break;
                     case "NAV1 Standby Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[4].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[2].ControllerValue == 0 ? "0" : bindings[2].ControllerValue.ToString().Substring(3, 2), ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav1Available.MsfsValue));
+                        bitmapBuilder.DrawText(Nav1StandbyFreq.ControllerValue == 0 ? "0" : Nav1StandbyFreq.ControllerValue.ToString().Substring(3, 2), ImageTool.Yellow, 40);
                         break;
                     case "NAV2 Active Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[1].ControllerValue == 0 ? "0" : bindings[1].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav2Available.MsfsValue));
+                        bitmapBuilder.DrawText((Nav2ActiveFreq.ControllerValue == 0 ? "0" : Nav2ActiveFreq.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Green, 40);
                         break;
                     case "NAV2 Active Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[1].ControllerValue == 0 ? "0" : bindings[1].ControllerValue.ToString().Substring(3, 2), ImageTool.Green, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav2Available.MsfsValue));
+                        bitmapBuilder.DrawText(Nav2ActiveFreq.ControllerValue == 0 ? "0" : Nav2ActiveFreq.ControllerValue.ToString().Substring(3, 2), ImageTool.Green, 40);
                         break;
                     case "NAV2 Standby Int":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText((bindings[3].ControllerValue == 0 ? "0" : bindings[3].ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav2Available.MsfsValue));
+                        bitmapBuilder.DrawText((Nav2StandbyFreq.ControllerValue == 0 ? "0" : Nav2StandbyFreq.ControllerValue.ToString().Substring(0, 3)) + ".", ImageTool.Yellow, 40);
                         break;
                     case "NAV2 Standby Float":
-                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(bindings[5].MsfsValue));
-                        bitmapBuilder.DrawText(bindings[3].ControllerValue == 0 ? "0" : bindings[3].ControllerValue.ToString().Substring(3, 2), ImageTool.Yellow, 40);
+                        bitmapBuilder.SetBackgroundImage(ImageTool.GetAvailableDisableImage(Nav2Available.MsfsValue));
+                        bitmapBuilder.DrawText(Nav2StandbyFreq.ControllerValue == 0 ? "0" : Nav2StandbyFreq.ControllerValue.ToString().Substring(3, 2), ImageTool.Yellow, 40);
                         break;
                 }
                 return bitmapBuilder.ToImage();
@@ -141,7 +140,7 @@
                 case "NAV1 Standby":
                 case "NAV1 Standby Int":
                 case "NAV1 Standby Float":
-                    bindings[6].SetControllerValue(1);
+                    Nav1Swap.SetControllerValue(1);
                     break;
                 case "NAV2 Active":
                 case "NAV2 Active Int":
@@ -149,17 +148,17 @@
                 case "NAV2 Standby":
                 case "NAV2 Standby Int":
                 case "NAV2 Standby Float":
-                    bindings[7].SetControllerValue(1);
+                    Nav2Swap.SetControllerValue(1);
                     break;
                 case "Int Reset":
                 case "Float Reset":
                     if (isVar1Active)
                     {
-                        bindings[6].SetControllerValue(1);
+                        Nav1Swap.SetControllerValue(1);
                     }
                     else
                     {
-                        bindings[7].SetControllerValue(1);
+                        Nav2Swap.SetControllerValue(1);
                     }
                     break;
             }
@@ -167,24 +166,35 @@
 
         public override void ApplyAdjustment(string actionParameter, int ticks)
         {
-            var bindingIndex = isVar1Active ? 2 : 3;
+            var binding = isVar1Active ? Nav1StandbyFreq : Nav2StandbyFreq;
             switch (actionParameter)
             {
                 case "Int":
-                    var com1int = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(0, 3));
-                    var com1dbl = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(3, 2));
+                    var com1int = int.Parse(binding.ControllerValue.ToString().Substring(0, 3));
+                    var com1dbl = int.Parse(binding.ControllerValue.ToString().Substring(3, 2));
                     var newInt = ConvertTool.ApplyAdjustment(com1int, ticks, 108, 117, 1, true);
-                    bindings[bindingIndex].SetControllerValue(newInt * 1000000 + com1dbl * 10000);
+                    binding.SetControllerValue(newInt * 1000000 + com1dbl * 10000);
                     break;
                 case "Float":
-                    var com1dbl1 = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(3, 2));
-                    var com1int1 = int.Parse(bindings[bindingIndex].ControllerValue.ToString().Substring(0, 3));
+                    var com1dbl1 = int.Parse(binding.ControllerValue.ToString().Substring(3, 2));
+                    var com1int1 = int.Parse(binding.ControllerValue.ToString().Substring(0, 3));
                     var newFloat = ConvertTool.ApplyAdjustment(com1dbl1, ticks, 0, 99, 1, true);
-                    bindings[bindingIndex].SetControllerValue(com1int1 * 1000000 + newFloat * 10000);
+                    binding.SetControllerValue(com1int1 * 1000000 + newFloat * 10000);
                     break;
             }
             EncoderActionNamesChanged();
             ButtonActionNamesChanged();
         }
+
+        bool isVar1Active = true;
+
+        readonly Binding Nav1ActiveFreq;
+        readonly Binding Nav2ActiveFreq;
+        readonly Binding Nav1StandbyFreq;
+        readonly Binding Nav2StandbyFreq;
+        readonly Binding Nav1Available;
+        readonly Binding Nav2Available;
+        readonly Binding Nav1Swap;
+        readonly Binding Nav2Swap;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/input/DefaultInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/DefaultInput.cs
@@ -1,32 +1,29 @@
 ﻿namespace Loupedeck.MsfsPlugin.input
 {
     using System.Collections.Generic;
+    using Loupedeck.MsfsPlugin.tools;
 
     public abstract class DefaultInput : PluginDynamicCommand, INotifiable
     {
-        protected readonly List<Binding> bindings = new List<Binding>();
-        protected static Binding Register(BindingKeys key, long? value = null) => MsfsData.Instance.Register(key, value);
+        protected IList<Binding> bindings => entity.bindings;   //>> Can be removed when all inputs declare individual bindings
 
         protected DefaultInput(string name, string desc, string category) : base(name, desc, category)
         {
+            entity = new CommonEntity();
             MsfsData.Instance.Register(this);
         }
 
         protected DefaultInput()
         {
+            entity = new CommonEntity();
             MsfsData.Instance.Register(this);
         }
 
-        public void Notify()
-        {
-            foreach (Binding binding in bindings)
-            {
-                if (binding.HasMSFSChanged())
-                {
-                    binding.Reset();
-                }
-            }
-        }
+        protected static Binding Register(BindingKeys key, long? value = null) => MsfsData.Instance.Register(key, value);   //>> Can be removed when all inputs declare individual bindings
+
+        protected Binding Bind(BindingKeys key, long? value = null) => entity.Bind(key, value);
+
+        public void Notify() => entity.Notify();
 
         protected override string GetCommandDisplayName(string actionParameter, PluginImageSize imageSize) => GetValue();
         protected override BitmapImage GetCommandImage(string actionParameter, PluginImageSize imageSize) => GetImage(imageSize);
@@ -34,5 +31,7 @@
         protected virtual string GetValue() => null;
         protected virtual BitmapImage GetImage(PluginImageSize imageSize) => null;
         protected virtual void ChangeValue() { }
+
+        readonly CommonEntity entity;
     }
 }

--- a/MsfsPlugin/MsfsPlugin/input/debug/SimCnxStateInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/debug/SimCnxStateInput.cs
@@ -8,7 +8,7 @@
     {
         public SimCnxStateInput() : base("ConnectionSimConnect", "Display SimConnect connection state", "Debug")
         {
-            bindings.Add(binding = Register(BindingKeys.CONNECTION));
+            binding = Bind(BindingKeys.CONNECTION);
         }
 
         protected override string GetValue() => binding.MsfsValue == 1 ? "connected" : binding.MsfsValue == 2 ? "trying to\nconnect" : "not\nconnected";

--- a/MsfsPlugin/MsfsPlugin/input/light/LightsDisplay.cs
+++ b/MsfsPlugin/MsfsPlugin/input/light/LightsDisplay.cs
@@ -8,15 +8,15 @@
     {
         public LightsDisplay() : base("External lights", "Display external lights on/off", "Lights")
         {
-            bindings.Add(nav = Register(BindingKeys.LIGHT_NAV));
-            bindings.Add(beacon = Register(BindingKeys.LIGHT_BEACON));
-            bindings.Add(taxi = Register(BindingKeys.LIGHT_TAXI));
-            bindings.Add(strobe = Register(BindingKeys.LIGHT_STROBE));
-            bindings.Add(landing = Register(BindingKeys.LIGHT_LANDING));
-            bindings.Add(wing = Register(BindingKeys.LIGHT_WING));
-            bindings.Add(logo = Register(BindingKeys.LIGHT_LOGO));
-            bindings.Add(recognition = Register(BindingKeys.LIGHT_RECOG));
-            bindings.Add(connection = Register(BindingKeys.CONNECTION));
+            nav = Bind(BindingKeys.LIGHT_NAV);
+            beacon = Bind(BindingKeys.LIGHT_BEACON);
+            taxi = Bind(BindingKeys.LIGHT_TAXI);
+            strobe = Bind(BindingKeys.LIGHT_STROBE);
+            landing = Bind(BindingKeys.LIGHT_LANDING);
+            wing = Bind(BindingKeys.LIGHT_WING);
+            logo = Bind(BindingKeys.LIGHT_LOGO);
+            recognition = Bind(BindingKeys.LIGHT_RECOG);
+            connection = Bind(BindingKeys.CONNECTION);
         }
 
         protected override BitmapImage GetCommandImage(string actionParameter, PluginImageSize imageSize)

--- a/MsfsPlugin/MsfsPlugin/input/misc/FuelDisplay.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/FuelDisplay.cs
@@ -3,14 +3,15 @@
     using System;
 
     using Loupedeck.MsfsPlugin.input;
+
     class FuelDisplay : DefaultInput
     {
         public FuelDisplay() : base("Fuel", "Display fuel left, flow and time before empty", "Misc")
         {
-            bindings.Add(fuelPercent = Register(BindingKeys.FUEL_PERCENT));
-            bindings.Add(fuelFlowGph = Register(BindingKeys.FUEL_FLOW_GPH));
-            bindings.Add(fuelFlowPph = Register(BindingKeys.FUEL_FLOW_PPH));
-            bindings.Add(fuelTimeLeft = Register(BindingKeys.FUEL_TIME_LEFT));
+            fuelPercent = Bind(BindingKeys.FUEL_PERCENT);
+            fuelFlowGph = Bind(BindingKeys.FUEL_FLOW_GPH);
+            fuelFlowPph = Bind(BindingKeys.FUEL_FLOW_PPH);
+            fuelTimeLeft = Bind(BindingKeys.FUEL_TIME_LEFT);
         }
 
         protected override string GetValue() =>

--- a/MsfsPlugin/MsfsPlugin/input/misc/ParkingBrakeInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/ParkingBrakeInput.cs
@@ -7,8 +7,7 @@
     {
         public ParkingBrakeInput() : base("Parking brake", "Display parking brakes state", "Misc")
         {
-            binding = Register(BindingKeys.PARKING_BRAKES);
-            bindings.Add(binding);
+            binding = Bind(BindingKeys.PARKING_BRAKES);
         }
 
         protected override void ChangeValue() => binding.SetControllerValue(ConvertTool.GetToggledValue(binding.ControllerValue));

--- a/MsfsPlugin/MsfsPlugin/input/misc/PauseInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/PauseInput.cs
@@ -7,8 +7,7 @@
     {
         public PauseInput() : base("Pause", "Pause", "Misc")
         {
-            binding = Register(BindingKeys.PAUSE);
-            bindings.Add(binding);
+            binding = Bind(BindingKeys.PAUSE);
         }
 
         protected override void ChangeValue() => binding.SetControllerValue(1);

--- a/MsfsPlugin/MsfsPlugin/input/misc/PitotInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/PitotInput.cs
@@ -7,8 +7,7 @@
     {
         public PitotInput() : base("Pitot", "Pitot heating", "Misc")
         {
-            binding = Register(BindingKeys.PITOT);
-            bindings.Add(binding);
+            binding = Bind(BindingKeys.PITOT);
         }
 
         protected override void ChangeValue() => binding.SetControllerValue(1);

--- a/MsfsPlugin/MsfsPlugin/input/misc/RPMInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/RPMInput.cs
@@ -9,20 +9,20 @@
     {
         public RPMInput() : base("RPM/N1", "Display RPM for or N1", "Misc")
         {
-            bindings.Add(engineType = Register(BindingKeys.ENGINE_TYPE));
-            bindings.Add(engineNumber = Register(BindingKeys.ENGINE_NUMBER));
-            bindings.Add(eng1Rpm = Register(BindingKeys.E1RPM));
-            bindings.Add(eng2Rpm = Register(BindingKeys.E2RPM));
-            bindings.Add(eng3Rpm = Register(BindingKeys.E3RPM));
-            bindings.Add(eng4Rpm = Register(BindingKeys.E4RPM));
-            bindings.Add(eng1N1 = Register(BindingKeys.E1N1));
-            bindings.Add(eng2N1 = Register(BindingKeys.E2N1));
-            bindings.Add(eng3N1 = Register(BindingKeys.E3N1));
-            bindings.Add(eng4N1 = Register(BindingKeys.E4N1));
-            bindings.Add(eng1N2 = Register(BindingKeys.E1N2));
-            bindings.Add(eng2N2 = Register(BindingKeys.E2N2));
-            bindings.Add(eng3N2 = Register(BindingKeys.E3N2));
-            bindings.Add(eng4N2 = Register(BindingKeys.E4N2));
+            engineType = Bind(BindingKeys.ENGINE_TYPE);
+            engineNumber = Bind(BindingKeys.ENGINE_NUMBER);
+            eng1Rpm = Bind(BindingKeys.E1RPM);
+            eng2Rpm = Bind(BindingKeys.E2RPM);
+            eng3Rpm = Bind(BindingKeys.E3RPM);
+            eng4Rpm = Bind(BindingKeys.E4RPM);
+            eng1N1 = Bind(BindingKeys.E1N1);
+            eng2N1 = Bind(BindingKeys.E2N1);
+            eng3N1 = Bind(BindingKeys.E3N1);
+            eng4N1 = Bind(BindingKeys.E4N1);
+            eng1N2 = Bind(BindingKeys.E1N2);
+            eng2N2 = Bind(BindingKeys.E2N2);
+            eng3N2 = Bind(BindingKeys.E3N2);
+            eng4N2 = Bind(BindingKeys.E4N2);
 
             RpmBindings = new List<Binding>() { eng1Rpm, eng2Rpm, eng3Rpm, eng4Rpm };
             N1Bindings = new List<Binding>() { eng1N1, eng2N1, eng3N1, eng4N1 };

--- a/MsfsPlugin/MsfsPlugin/input/misc/SpoilerArmInput.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/SpoilerArmInput.cs
@@ -7,8 +7,7 @@
     {
         public SpoilerArmInput() : base("SpoilerArm", "Spoiler Arm", "Misc")
         {
-            binding = Register(BindingKeys.SPOILERS_ARM);
-            bindings.Add(binding);
+            binding = Bind(BindingKeys.SPOILERS_ARM);
         }
 
         protected override void ChangeValue() => binding.SetControllerValue(1);

--- a/MsfsPlugin/MsfsPlugin/input/misc/WeatherDisplay.cs
+++ b/MsfsPlugin/MsfsPlugin/input/misc/WeatherDisplay.cs
@@ -6,11 +6,11 @@
     {
         public WeatherDisplay() : base("Weather", "Display weather parameters", "Misc")
         {
-            bindings.Add(oat = Register(BindingKeys.AIR_TEMP));
-            bindings.Add(windDir = Register(BindingKeys.WIND_DIRECTION));
-            bindings.Add(windVel = Register(BindingKeys.WIND_SPEED));
-            bindings.Add(visib = Register(BindingKeys.VISIBILITY));
-            bindings.Add(pressure = Register(BindingKeys.SEA_LEVEL_PRESSURE));
+            oat = Bind(BindingKeys.AIR_TEMP);
+            windDir = Bind(BindingKeys.WIND_DIRECTION);
+            windVel = Bind(BindingKeys.WIND_SPEED);
+            visib = Bind(BindingKeys.VISIBILITY);
+            pressure = Bind(BindingKeys.SEA_LEVEL_PRESSURE);
         }
 
         protected override string GetValue() => $"{OatText}\n{WindText}\n{VisibilityText}\n{PressureText}";

--- a/MsfsPlugin/MsfsPlugin/input/nav/APWPDisplay.cs
+++ b/MsfsPlugin/MsfsPlugin/input/nav/APWPDisplay.cs
@@ -3,17 +3,28 @@
     using System;
 
     using Loupedeck.MsfsPlugin.input;
+    using Loupedeck.MsfsPlugin.tools;
+
     class APWPDisplay : DefaultInput
     {
         public APWPDisplay() : base("WP", "Display next WP data", "Nav")
         {
-            bindings.Add(Register(BindingKeys.AP_NEXT_WP_ID));
-            bindings.Add(Register(BindingKeys.AP_NEXT_WP_DIST));
-            bindings.Add(Register(BindingKeys.AP_NEXT_WP_ETE));
-            bindings.Add(Register(BindingKeys.AP_NEXT_WP_HEADING));
+            wpId = Bind(BindingKeys.AP_NEXT_WP_ID);
+            wpDist = Bind(BindingKeys.AP_NEXT_WP_DIST);
+            wpETE = Bind(BindingKeys.AP_NEXT_WP_ETE);
+            wpHdg = Bind(BindingKeys.AP_NEXT_WP_HEADING);
         }
 
-        protected override string GetValue() => "WP " + bindings[0].ControllerValue + "\n" + bindings[1].ControllerValue + " mn \n" + TimeSpan.FromSeconds(bindings[2].ControllerValue).ToString() + "\n" + bindings[3].ControllerValue + " °";
+        protected override string GetValue() =>
+            "WP " + wpId.ControllerValue + "\n" +
+            ConvertTool.Round(wpDist.ControllerValue / 10.0, 1) + " nm \n" +
+            TimeSpan.FromSeconds(wpETE.ControllerValue).ToString() + "\n" +
+            wpHdg.ControllerValue + " °";
+
+        readonly Binding wpId;
+        readonly Binding wpDist;
+        readonly Binding wpETE;
+        readonly Binding wpHdg;
     }
 }
 

--- a/MsfsPlugin/MsfsPlugin/msfs/DataTransferIn.cs
+++ b/MsfsPlugin/MsfsPlugin/msfs/DataTransferIn.cs
@@ -45,7 +45,7 @@
             SetMsfsValue(BindingKeys.FUEL_PERCENT, (Int64)Math.Round(reader.fuelQuantity * 100.0 / reader.fuelCapacity));
             SetMsfsValue(BindingKeys.FUEL_TIME_LEFT, (Int64)(reader.fuelQuantity / reader.FuelGph * 3600));
             SetMsfsValue(BindingKeys.AP_NEXT_WP_ID, reader.wpID);
-            SetMsfsValue(BindingKeys.AP_NEXT_WP_DIST, (Int64)Math.Round(reader.wpDistance * 0.00053996f, 1));
+            SetMsfsValue(BindingKeys.AP_NEXT_WP_DIST, (Int64)Math.Round(reader.wpDistance * 0.00053996f * 10, 1));
             SetMsfsValue(BindingKeys.AP_NEXT_WP_ETE, reader.wpETE);
             SetMsfsValue(BindingKeys.AP_NEXT_WP_HEADING, reader.wpBearing);
             SetMsfsValue(BindingKeys.ENGINE_TYPE, reader.engineType);
@@ -97,13 +97,13 @@
             SetMsfsValue(BindingKeys.COM1_ACTIVE_FREQUENCY, reader.COM1ActiveFreq);
             SetMsfsValue(BindingKeys.COM1_STBY, reader.COM1StbFreq);
             SetMsfsValue(BindingKeys.COM1_AVAILABLE, reader.COM1Available);
-            SetMsfsValue(BindingKeys.COM1_STATUS, reader.COM1Status);
+            //SetMsfsValue(BindingKeys.COM1_STATUS, reader.COM1Status);
             //SetMsfsValue(BindingKeys.COM1_ACTIVE_FREQUENCY_TYPE, COMtypeToInt(reader.COM1Type));
 
             SetMsfsValue(BindingKeys.COM2_ACTIVE_FREQUENCY, reader.COM2ActiveFreq);
             SetMsfsValue(BindingKeys.COM2_STBY, reader.COM2StbFreq);
             SetMsfsValue(BindingKeys.COM2_AVAILABLE, reader.COM2Available);
-            SetMsfsValue(BindingKeys.COM2_STATUS, reader.COM2Status);
+            //SetMsfsValue(BindingKeys.COM2_STATUS, reader.COM2Status);
             //SetMsfsValue(BindingKeys.COM2_ACTIVE_FREQUENCY_TYPE, this.COMtypeToInt(reader.COM2Type));
 
             SetMsfsValue(BindingKeys.SIM_RATE, (Int64)(reader.simRate * 100));
@@ -188,7 +188,7 @@
             AddReaderDef("GPS FLIGHT PLAN WP INDEX", "Number", SimType.INT64);                            //        wpID                 AP_NEXT_WP_ID
             AddReaderDef("GPS WP DISTANCE", "Meters", SimType.INT64);                                     //        wpDistance           AP_NEXT_WP_DIST
             AddReaderDef("GPS WP ETE", "Seconds", SimType.INT64);                                         //        wpETE                AP_NEXT_WP_ETE
-            AddReaderDef("GPS WP BEARING", "Radians", SimType.INT64);                                     //        wpBearing            AP_NEXT_WP_HEADING
+            AddReaderDef("GPS WP BEARING", "degrees", SimType.INT64);                                     //        wpBearing            AP_NEXT_WP_HEADING
             AddReaderDef("GPS FLIGHT PLAN WP COUNT", "Number", SimType.INT64);                            //        wpCount              - no binding -
             AddReaderDef("AUTOPILOT HEADING LOCK DIR", "degrees", SimType.INT64);                         //        apHeading            AP_HEADING
             AddReaderDef("PLANE HEADING DEGREES MAGNETIC", "degrees", SimType.FLOAT64);                   //        planeHeading         HEADING

--- a/MsfsPlugin/MsfsPlugin/tools/CommonEntity.cs
+++ b/MsfsPlugin/MsfsPlugin/tools/CommonEntity.cs
@@ -1,0 +1,32 @@
+﻿namespace Loupedeck.MsfsPlugin.tools
+{
+    using System.Collections.Generic;
+
+    internal class CommonEntity
+    {
+        public readonly IList<Binding> bindings;
+
+        public CommonEntity()
+        {
+            bindings = new List<Binding>();
+        }
+
+        public void Notify()
+        {
+            foreach (Binding binding in bindings)
+            {
+                if (binding.HasMSFSChanged())
+                {
+                    binding.Reset();
+                }
+            }
+        }
+
+        public Binding Bind(BindingKeys key, long? value = null)
+        {
+            Binding binding = MsfsData.Instance.Register(key, value);
+            bindings.Add(binding);
+            return binding;
+        }
+    }
+}


### PR DESCRIPTION
Fixes for WP display:
1) Fixed the bearing value display
2) Made display of distance more accurate

A new class, CommonEntity, is introduced. It centralizes code that was previously duplicated in DefaultFolder, DefaultEncoder and DefaultInput: 1) Code implementing the INotifier interface.
2) Registering a binding with a certain key and initial value and adding it to the collection used for notification. 3) The collection of bindings in a folder, encoder or input.

Apart from that a lot of refactoring in folders: They now all use meaningful names of bindings rather than indexing in a list. The array still exists but is now hidden in CommonEntity. Similar refactorization of encoders and inputs will be made soon and then the binding collection in CommonEntity will be made private.